### PR TITLE
Ignore reactions added by the author

### DIFF
--- a/src/models/member.js
+++ b/src/models/member.js
@@ -8,7 +8,8 @@ const memberSchema = new mongoose.Schema({
 	cookies: [
 		{
 			messageId: String,
-			date: Date
+			date: Date,
+			senderId: String
 		}
 	]
 });


### PR DESCRIPTION
Fixes a bug where members were able to increase their own score by adding a 🍪 reaction to a message they wrote.

Also stores the ID of the 'sender' of the reaction for future use.